### PR TITLE
Fixes for deep convolutions on weak GPUs and EGL

### DIFF
--- a/fyusenet/base/bufferspec.h
+++ b/fyusenet/base/bufferspec.h
@@ -310,6 +310,29 @@ class BufferSpec {
         return *this;
     }
 
+
+    /**
+     * @brief Check if a sized format is an integral (integer) datatype 
+     * 
+     * @retval true sized format is an integral datatype
+     * @retval false otherwise
+     *
+     * Integral datatypes on the GPU require to be read as integers in the shaders, whereas non-integral
+     * datatypes are read as floating-point values in the shaders.
+     */
+    static bool isIntegral(sizedformat fmt) {
+        switch (fmt) {
+            case sizedformat::SINGLE32UI:
+            case sizedformat::RG32UI:
+            case sizedformat::RGB32UI:
+            case sizedformat::RGBA32UI:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+
     /**
      * @brief Get sized format by number of channels and data type
      *
@@ -324,11 +347,10 @@ class BufferSpec {
     static std::pair<sizedformat, genericformat> formatByChannels(int channels, dtype type) {
         using sz = sizedformat;
         using gn = genericformat;
-        // NOTE (mw) we skip RGB texture formats due to OpenGL ES limitations
-        static sizedformat flt32sfmt[4] = {sz::SINGLE32F, sz::RG32F, sz::RGBA32F, sz::RGBA32F};
-        static sizedformat flt16sfmt[4] = {sz::SINGLE16F, sz::RG16F, sz::RGBA16F, sz::RGBA16F};
-        static sizedformat uintsfmt[4] = {sz::SINGLE32UI, sz::RG32UI, sz::RGBA32UI, sz::RGBA32UI};
-        static sizedformat bytesfmt[4] = {sz::RED8, sz::RG8, sz::RGBA8, sz::RGBA8};
+        static sizedformat flt32sfmt[4] = {sz::SINGLE32F, sz::RG32F, sz::RGB32F, sz::RGBA32F};
+        static sizedformat flt16sfmt[4] = {sz::SINGLE16F, sz::RG16F, sz::RGB16F, sz::RGBA16F};
+        static sizedformat uintsfmt[4] = {sz::SINGLE32UI, sz::RG32UI, sz::RGB32UI, sz::RGBA32UI};
+        static sizedformat bytesfmt[4] = {sz::RED8, sz::RG8, sz::RGB8, sz::RGBA8};
         static genericformat gfmt[4] = {gn::RED, gn::RG, gn::RGB, gn::RGBA};
         static genericformat gifmt[4] = {gn::RED_INT, gn::RG_INT, gn::RGB_INT, gn::RGBA_INT};
         assert((channels > 0) && (channels <= 4));

--- a/fyusenet/gl/egl/glcontext_egl.cpp
+++ b/fyusenet/gl/egl/glcontext_egl.cpp
@@ -210,12 +210,12 @@ void GLContext::init() {
         display = eglGetPlatformDisplayEXT(EGL_PLATFORM_DEVICE_EXT, eglDevices[i], 0);
         if (display != EGL_NO_DISPLAY) {
             if (const char *vendor = eglQueryDeviceStringEXT(eglDevices[i], EGL_VENDOR); vendor) {
-                printf("vendor: %s\n", vendor);
-            } else printf("no vendor\n");
+                // TODO (mw) filter by vendor
+            }
 #ifdef EGL_RENDERER_EXT
             if (const char *render = eglQueryDeviceStringEXT(eglDevices[i], EGL_RENDERER_EXT); render) {
-                printf("render: %s\n", render);
-            } else printf("no render\n");
+                // TODO (mw) filter by renderer
+            }
 #endif
             // --------------------------------------------------------------
             // If we found a display, try to use it, break out of the loop on

--- a/fyusenet/gpu/addsublayer.cpp
+++ b/fyusenet/gpu/addsublayer.cpp
@@ -71,14 +71,14 @@ std::vector<BufferSpec> AddSubLayer::getRequiredInputBuffers() const {
             auto format = BufferSpec::formatByChannels(inputChannels_, TEXTURE_TYPE_DEFAULT);
             result.emplace_back(channel++, port, width_+2*inputPadding_, height_ + 2*inputPadding_,
                                 format.first, format.second, TEXTURE_TYPE_DEFAULT,
-                                BufferSpec::FUNCTION_SOURCE);
+                                BufferSpec::FUNCTION_SOURCE, rem);
             if (port == 0) texturesPerPort_++;
         } else {
             while (rem > 0) {
                 result.emplace_back(channel++, port,
                                     width_ + 2*inputPadding_, height_ + 2*inputPadding_,
                                     TEXTURE_IFORMAT_4,TEXTURE_FORMAT_4,TEXTURE_TYPE_DEFAULT,
-                                    BufferSpec::FUNCTION_SOURCE);
+                                    BufferSpec::FUNCTION_SOURCE, std::min(rem, PIXEL_PACKING));
                 rem -= PIXEL_PACKING;
                 if (port == 0) texturesPerPort_++;
             }

--- a/fyusenet/gpu/concatlayer.cpp
+++ b/fyusenet/gpu/concatlayer.cpp
@@ -129,7 +129,7 @@ std::vector<BufferSpec> ConcatLayer::getRequiredInputBuffers() const {
             result.push_back(BufferSpec(channel++, connindex, width_ + 2*inputPadding_,
                                         height_ + 2*inputPadding_,
                                         TEXTURE_IFORMAT_4, TEXTURE_FORMAT_4, TEXTURE_TYPE_DEFAULT,
-                                        BufferSpec::CONCAT_SOURCE).interpolation(BufferSpec::interp::ANY));
+                                        BufferSpec::CONCAT_SOURCE, std::min(rem, PIXEL_PACKING)).interpolation(BufferSpec::interp::ANY));
             rem -= PIXEL_PACKING;
         }
         connindex++;
@@ -148,7 +148,7 @@ std::vector<BufferSpec> ConcatLayer::getRequiredOutputBuffers() const {
     while (rem > 0) {
         result.push_back(BufferSpec(channel++, 0, viewport_[0], viewport_[1],
                                     TEXTURE_IFORMAT_4,TEXTURE_FORMAT_4,TEXTURE_TYPE_DEFAULT,
-                                    BufferSpec::CONCAT_DEST).passThrough(!consolidationRender_).interpolation(BufferSpec::interp::ANY));
+                                    BufferSpec::CONCAT_DEST, std::min(rem, PIXEL_PACKING)).passThrough(!consolidationRender_).interpolation(BufferSpec::interp::ANY));
         rem -= PIXEL_PACKING;
     }
     return result;

--- a/fyusenet/gpu/deep/deepconvlayerNxN.h
+++ b/fyusenet/gpu/deep/deepconvlayerNxN.h
@@ -51,7 +51,6 @@ class DeepConvLayerNxN : public DeepConvLayerBase {
     // ------------------------------------------------------------------------
     // Non-public methods
     // ------------------------------------------------------------------------
-    void setupNetworkPolygons(VAO *vao) override;
     void compileConvolutionShaders(const char *preproc) override;
     unistateptr initShader(programptr shader, int horizOffset, int kernelOffset, int kernelY);
     void partialRender();

--- a/fyusenet/gpu/deep/deepconvlayerbase.cpp
+++ b/fyusenet/gpu/deep/deepconvlayerbase.cpp
@@ -264,7 +264,7 @@ bool DeepConvLayerBase::isApplicable() const {
  *
  * As opposed to the shallow tensor handling, it is not efficient to use multiple render passes
  * with changing uniforms for the convolution (at least not in my tests on mobile GPUs). Instead,
- * a different path is chosen, which packs the convolution coefficients into textures and use a
+ * a different path is chosen, which packs the convolution coefficients into textures and uses a
  * few tricks - when available.
  *
  * The texture format for the convolution coefficients is as follows:
@@ -274,7 +274,7 @@ bool DeepConvLayerBase::isApplicable() const {
  *   - Texture \e width corresponds to the number of input channels multiplied by the convolution
  *     kernel size, padded for even size (there is an additional tweak, see below for details)
  *   - Each pixel in the texture corresponds to 4 (or 8) convolution coefficients that are laid
- *     out as as part of 4x4 matrices
+ *     out as parts of 4x4 matrices
  *   - Four (4) consecutive pixels in a row represent a 4x4 matrix with the input channels as their
  *     column space and the output channels as their row space
  *   - Depending on the convolution kernel size, \e k neighboring 4x4 matrices horizontally
@@ -569,10 +569,6 @@ size_t DeepConvLayerBase::shaderPreprocessing(char *preproc, size_t maxChars) {
         strncat(preproc, "#define PRE_G71\n", mc);
         mc = (ssize_t)maxChars - (ssize_t)strlen(preproc);  // ouch
     }
-#ifdef HIGH_PRECISION
-    strncat(preproc, "#define HIGH_PRECISION\n", mc);
-    mc = maxChars-strlen(preproc);
-#endif
     snprintf(extra, sizeof(extra), "#define KERNEL %d\n",kernel_);
     strncat(preproc, extra, mc);
     mc -= (ssize_t)strlen(extra);
@@ -715,9 +711,9 @@ void DeepConvLayerBase::setupNetworkPolygons(VAO *vao) {
     if ((kernel_ & 1) == 0) {
         THROW_EXCEPTION_ARGS(FynException,"Unsupported window size");
     } else {
-        for (int w = -((kernel_ - 1) / 2) ; w <= ((kernel_- 1 ) / 2); w++) {            // currently only odd window sizes are supported
-            std::vector<DeepTiler::Tile> tiles = tiler_->createInputTiles(0,w*dilation_[1]);
-            int offset = (w + ((kernel_ - 1) / 2))*tiler_->numInputTiles()*4;
+        for (int w = -((kernel_ - 1) / 2) ; w <= ((kernel_- 1 ) / 2); w++) {            // currently only odd kernel sizes are supported
+            std::vector<DeepTiler::Tile> tiles = tiler_->createInputTiles(0, w * dilation_[1]);
+            int offset = (w + ((kernel_ - 1) / 2)) * tiler_->numInputTiles() * 4;
             for (DeepTiler::Tile & tile : tiles) {
                 tile.toDisplacement(defex,texdata,offset);
                 tile.lowClamp(texdata, offset+2);

--- a/fyusenet/gpu/deep/deepgemmlayer.h
+++ b/fyusenet/gpu/deep/deepgemmlayer.h
@@ -24,10 +24,7 @@
 #include "deepconvlayerbase.h"
 
 //------------------------------------- Public Declarations ----------------------------------------
-namespace fyusion {
-namespace fyusenet {
-namespace gpu {
-namespace deep {
+namespace fyusion::fyusenet::gpu::deep {
 
 /**
  * @brief GEMM layer that implements GEMM as 1x1 convolutions
@@ -69,10 +66,7 @@ class DeepGEMMLayer : public DeepConvLayerBase {
     bool usePoints_ = false;                    //!< Indicator if point-based rendering should be used (for 1x1 sized "tiles")
 };
 
-} // deep namespace
-} // gpu namespace
-} // fyusenet namespace
-} // fyusion namespace
+} // fyusion::fyusenet::gpu::deep namespace
 
 
 // vim: set expandtab ts=4 sw=4:

--- a/fyusenet/gpu/deep2shallow.cpp
+++ b/fyusenet/gpu/deep2shallow.cpp
@@ -122,7 +122,7 @@ std::vector<BufferSpec> Deep2ShallowLayer::getRequiredOutputBuffers() const {
     for (int i=0; i < outputChannels_; i += PIXEL_PACKING) {
         result.emplace_back(channel++, 0, viewport_[0], viewport_[1],
                             TEXTURE_IFORMAT_4, TEXTURE_FORMAT_4, TEXTURE_TYPE_DEFAULT,
-                            BufferSpec::FUNCTION_DEST);
+                            BufferSpec::FUNCTION_DEST, std::min(outputChannels_-i, PIXEL_PACKING));
     }
     return result;
 }

--- a/fyusenet/gpu/deep2shallow.h
+++ b/fyusenet/gpu/deep2shallow.h
@@ -52,8 +52,8 @@ class Deep2ShallowLayer : public deep::DeepLayerBase {
     void setup() override;
     void cleanup() override;
     void forward(uint64_t sequence, StateToken * state) override;
-    std::vector<BufferSpec> getRequiredInputBuffers() const override;
-    std::vector<BufferSpec> getRequiredOutputBuffers() const override;
+    [[nodiscard]] std::vector<BufferSpec> getRequiredInputBuffers() const override;
+    [[nodiscard]] std::vector<BufferSpec> getRequiredOutputBuffers() const override;
  protected:
     // ------------------------------------------------------------------------
     // Non-public methods

--- a/fyusenet/gpu/functionlayer.cpp
+++ b/fyusenet/gpu/functionlayer.cpp
@@ -102,7 +102,7 @@ std::vector<BufferSpec> FunctionLayer::getRequiredInputBuffers() const {
                 result.emplace_back(channel++, 0,
                                     width_ + 2 * inputPadding_, height_ + 2 * inputPadding_,
                                     TEXTURE_IFORMAT_4, TEXTURE_FORMAT_4, TEXTURE_TYPE_DEFAULT,
-                                    BufferSpec::FUNCTION_SOURCE);
+                                    BufferSpec::FUNCTION_SOURCE, std::min(rem, PIXEL_PACKING));
                 rem -= PIXEL_PACKING;
             }
         }
@@ -128,7 +128,7 @@ std::vector<BufferSpec> FunctionLayer::getRequiredOutputBuffers() const {
             result.emplace_back(channel++, 0,
                                 viewport_[0], viewport_[1],
                                 TEXTURE_IFORMAT_4, TEXTURE_FORMAT_4, TEXTURE_TYPE_DEFAULT,
-                                BufferSpec::FUNCTION_DEST);
+                                BufferSpec::FUNCTION_DEST, std::min(PIXEL_PACKING, rem));
             rem -= PIXEL_PACKING;
         }
     }

--- a/fyusenet/gpu/poolinglayer.cpp
+++ b/fyusenet/gpu/poolinglayer.cpp
@@ -96,7 +96,7 @@ std::vector<BufferSpec> PoolingLayer::getRequiredInputBuffers() const {
             result.emplace_back(channel++, 0,
                                 width_ + 2 * inputPadding_, height_ + 2 * inputPadding_,
                                 TEXTURE_IFORMAT_4, TEXTURE_FORMAT_4, TEXTURE_TYPE_DEFAULT,
-                                BufferSpec::FUNCTION_SOURCE);
+                                BufferSpec::FUNCTION_SOURCE, std::min(rem, PIXEL_PACKING));
             rem -= PIXEL_PACKING;
         }
     }
@@ -115,7 +115,7 @@ std::vector<BufferSpec> PoolingLayer::getRequiredOutputBuffers() const {
         result.emplace_back(channel++, 0,
                             viewport_[0], viewport_[1],
                             TEXTURE_IFORMAT_4, TEXTURE_FORMAT_4, TEXTURE_TYPE_DEFAULT,
-                            BufferSpec::FUNCTION_DEST);
+                            BufferSpec::FUNCTION_DEST, std::min(rem, PIXEL_PACKING));
         rem -= PIXEL_PACKING;
     }
     return result;

--- a/fyusenet/gpu/shaders/deep/deepconvNxN_partial.vert
+++ b/fyusenet/gpu/shaders/deep/deepconvNxN_partial.vert
@@ -43,6 +43,7 @@ uniform int instancesPerTile;
 uniform int horizOffset;
 uniform int kernelOffset;
 uniform int numParts;
+uniform float textureStep;
 
 void main(void) {
   gl_Position = vec4(attributes0.x, attributes0.y, 0.0, 1.0);
@@ -55,7 +56,8 @@ void main(void) {
   // Displace texture coordinates of input tile for kernel window shift (horiz + vert)
   int intile = instance / instancesPerTile;
   int vkernelidx = instance % instancesPerTile;
-  texCoord.xy += texelFetch(inputDisplacements, ivec2(intile, numParts * vkernelidx + horizOffset),0).rg;
+  texCoord.xy += texelFetch(inputDisplacements, ivec2(intile, vkernelidx),0).rg;
+  texCoord.x += float(horizOffset) * textureStep;
 #ifdef NO_HALF
   int inchan = 4 * intile * KERNEL + kernelOffset * 4;
 #else

--- a/fyusenet/gpu/shallow2deep.cpp
+++ b/fyusenet/gpu/shallow2deep.cpp
@@ -110,10 +110,12 @@ void Shallow2DeepLayer::cleanup() {
 std::vector<BufferSpec> Shallow2DeepLayer::getRequiredInputBuffers() const {
     std::vector<BufferSpec> result;
     int channel = 0;
-    if (inputChannels_ < PIXEL_PACKING) {
+    if (inputChannels_ <= PIXEL_PACKING) {
+        // NOTE (mw) technically this type of layer is not needed for this case, as deep format
+        // and shallow format are the same here, exception would be if padding has to be added
         // for input textures, we support textures with less than 4 channels (might be from upload)
         auto format = BufferSpec::formatByChannels(inputChannels_, TEXTURE_TYPE_DEFAULT);
-        result.emplace_back(channel++, 0, width_+2*inputPadding_, height_+2*inputPadding_,
+        result.emplace_back(channel++, 0, width_ + 2*inputPadding_, height_ + 2*inputPadding_,
                             format.first, format.second, TEXTURE_TYPE_DEFAULT,
                             BufferSpec::FUNCTION_SOURCE, inputChannels_);
     } else {
@@ -122,7 +124,7 @@ std::vector<BufferSpec> Shallow2DeepLayer::getRequiredInputBuffers() const {
             result.emplace_back(channel++, 0,
                                 width_ + 2*inputPadding_, height_ + 2*inputPadding_,
                                 TEXTURE_IFORMAT_4,TEXTURE_FORMAT_4,TEXTURE_TYPE_DEFAULT,
-                                BufferSpec::FUNCTION_SOURCE);
+                                BufferSpec::FUNCTION_SOURCE, std::min(rem, PIXEL_PACKING));
             rem -= PIXEL_PACKING;
         }
     }

--- a/fyusenet/gpu/uploadlayer.cpp
+++ b/fyusenet/gpu/uploadlayer.cpp
@@ -252,7 +252,7 @@ std::vector<BufferSpec> UploadLayer::getRequiredOutputBuffers() const {
                 result.push_back(BufferSpec(channelidx++, 0,
                                             width_ + 2 * inputPadding_, height_ + 2 * inputPadding_,
                                             TEXTURE_IFORMAT_4, TEXTURE_FORMAT_4, TEXTURE_TYPE_DEFAULT,
-                                            BufferSpec::GPU_DEST).async(async_).multi((async_) ? ASYNC_BUFFERS : 1));
+                                            BufferSpec::GPU_DEST, std::min(rem, PIXEL_PACKING)).async(async_).multi((async_) ? ASYNC_BUFFERS : 1));
                 rem -= LayerBase::PIXEL_PACKING;
             }
         }

--- a/fyusenet/gpu/vanilla/convlayerbase_vanilla.cpp
+++ b/fyusenet/gpu/vanilla/convlayerbase_vanilla.cpp
@@ -217,12 +217,12 @@ std::vector<BufferSpec> ConvLayerBase::getRequiredInputBuffers() const {
         auto format = BufferSpec::formatByChannels(inputChannels_, TEXTURE_TYPE_DEFAULT);
         result.emplace_back(channel, 0, width_ + 2*inputPadding_, height_ + 2*inputPadding_,
                             format.first, format.second, TEXTURE_TYPE_DEFAULT,
-                            BufferSpec::FUNCTION_SOURCE);
+                            BufferSpec::FUNCTION_SOURCE, rem);
     } else {
         while (rem > 0) {
             result.emplace_back(channel++, 0, width_ + 2*inputPadding_, height_ + 2*inputPadding_,
                                 TEXTURE_IFORMAT_4, TEXTURE_FORMAT_4, TEXTURE_TYPE_DEFAULT,
-                                BufferSpec::FUNCTION_SOURCE);
+                                BufferSpec::FUNCTION_SOURCE, std::min(PIXEL_PACKING, rem));
             rem -= PIXEL_PACKING;
         }
     }
@@ -232,7 +232,7 @@ std::vector<BufferSpec> ConvLayerBase::getRequiredInputBuffers() const {
         while (rem > 0) {
             result.emplace_back(channel++, 1, residualViewport_[0], residualViewport_[1],
                                 TEXTURE_IFORMAT_4, TEXTURE_FORMAT_4, TEXTURE_TYPE_DEFAULT,
-                                BufferSpec::RESIDUAL_SOURCE);
+                                BufferSpec::RESIDUAL_SOURCE, std::min(PIXEL_PACKING, rem));
             rem -= PIXEL_PACKING;
         }
     }
@@ -250,7 +250,7 @@ std::vector<BufferSpec> ConvLayerBase::getRequiredOutputBuffers() const {
     while (rem > 0) {
         result.emplace_back(channel++, 0, viewport_[0], viewport_[1],
                             TEXTURE_IFORMAT_4, TEXTURE_FORMAT_4, TEXTURE_TYPE_DEFAULT,
-                            BufferSpec::FUNCTION_DEST);
+                            BufferSpec::FUNCTION_DEST, std::min(PIXEL_PACKING, rem));
         rem -= PIXEL_PACKING;
     }
     return result;

--- a/samples/desktop/CMakeLists.txt
+++ b/samples/desktop/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 #----------------------------------------------------------------------------------
 
 if (NOT WIN32)
-  set(DEFAULT_LIBS stdc++ pthread m)
+  set(DEFAULT_LIBS stdc++ pthread m atomic)
 else()
   set(DEFAULT_LIBS "")
 endif()

--- a/samples/desktop/stylenet.cpp
+++ b/samples/desktop/stylenet.cpp
@@ -52,8 +52,9 @@ static float * readImage(const std::string& imageFile, int & width, int & height
 static void writeImage(const float *rgba, int width, int height, const std::string& fileName) {
     assert(rgba);
     uint8_t *rgb = new uint8_t[width*height*3];
-    for (int y=0; y<height; y++) {
-        for (int x=0; x<width; x++) {
+    // FIXME (mw) this code silently assumes that when we download 3-channel data it will always be extended to 4-channel data
+    for (int y=0; y < height; y++) {
+        for (int x=0; x < width; x++) {
             rgb[(y*width+x)*3] = (uint8_t)(rgba[(y*width+x)*4]*255.f);
             rgb[(y*width+x)*3+1] = (uint8_t)(rgba[(y*width+x)*4+1]*255.f);
             rgb[(y*width+x)*3+2] = (uint8_t)(rgba[(y*width+x)*4+2]*255.f);

--- a/samples/samplenetworks/stylenet3x3.cpp
+++ b/samples/samplenetworks/stylenet3x3.cpp
@@ -115,7 +115,7 @@ fyusion::fyusenet::CompiledLayers StyleNet3x3::buildLayers() {
 
     if (download_) {
         auto * down = new gpu::UpDownLayerBuilder(gpu::UpDownLayerBuilder::DOWNLOAD, "download");
-        down->shape(4, height_, width_, 4).context(context()).number(layer_ids::DOWNLOAD);
+        down->shape(3, height_, width_, 3).context(context()).number(layer_ids::DOWNLOAD);
 #ifdef FYUSENET_MULTITHREADING
         if (async_) down->async().callback(std::bind(&StyleNet3x3::internalDLCallback, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 #endif

--- a/samples/samplenetworks/stylenet9x9.cpp
+++ b/samples/samplenetworks/stylenet9x9.cpp
@@ -140,7 +140,7 @@ fyusion::fyusenet::CompiledLayers StyleNet9x9::buildLayers() {
 
     if (download_) {
         gpu::UpDownLayerBuilder * down = new gpu::UpDownLayerBuilder(gpu::UpDownLayerBuilder::DOWNLOAD, "download");
-        down->shape(4, height_, width_, 4).context(context()).number(layer_ids::DOWNLOAD);
+        down->shape(3, height_, width_, 3).context(context()).number(layer_ids::DOWNLOAD);
 #ifdef FYUSENET_MULTITHREADING
         if (async_) down->async().callback(std::bind(&StyleNet9x9::internalDLCallback, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 #endif

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -83,7 +83,7 @@ endif()
 if (ANDROID)
   set(DEFAULT_LIBS ${CXX_LIBS} gtest log)
 else()
-  set(DEFAULT_LIBS ${CXX_LIBS} gtest)
+  set(DEFAULT_LIBS ${CXX_LIBS} gtest atomic)
 endif()
 
 #----------------------------------------------------------------------------------


### PR DESCRIPTION
This fixes two things:
 1. a bug in wider deep-format convolutions on weaker GPUs (with smaller vertex/fragment interfaces) that botched the convolution results. That's what I get for testing with beefy GPUs
 2. Improved initialization (or so I hope) for EGL contexts, especially when there is more than one EGL backend present on the system

It also addresses some points regarding the handling of 3-channel textures, which are a nuisance under GL/ES. I made it a a bit more flexible, but this is something that should be addressed more thoroughly.