### PR TITLE
Added support for OpenGLES and EGL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,13 @@ if (BUILD_TARGET STREQUAL "Desktop")
 endif()
 
 if (BUILD_TARGET STREQUAL "Desktop")
-  find_package(OpenGL REQUIRED)
+  if (USE_EGL STREQUAL ON)
+    find_package(OpenGL REQUIRED)
+  else
+    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
+    find_package(OpenGLES REQUIRED)
+    find_package(EGL REQUIRED)
+  endif()
 endif()
 
 if (APPLE OR BUILD_TARGET STREQUAL "Web")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,9 +46,9 @@ if (BUILD_TARGET STREQUAL "Desktop")
 endif()
 
 if (BUILD_TARGET STREQUAL "Desktop")
-  if (USE_EGL STREQUAL ON)
+  if (USE_EGL STREQUAL OFF)
     find_package(OpenGL REQUIRED)
-  else
+  else()
     set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
     find_package(OpenGLES REQUIRED)
     find_package(EGL REQUIRED)

--- a/cmake/FindEGL.cmake
+++ b/cmake/FindEGL.cmake
@@ -1,0 +1,179 @@
+#.rst:
+# FindEGL
+# -------
+#
+# Try to find EGL.
+#
+# This will define the following variables:
+#
+# ``EGL_FOUND``
+#     True if (the requested version of) EGL is available
+# ``EGL_VERSION``
+#     The version of EGL; note that this is the API version defined in the
+#     headers, rather than the version of the implementation (eg: Mesa)
+# ``EGL_LIBRARIES``
+#     This can be passed to target_link_libraries() instead of the ``EGL::EGL``
+#     target
+# ``EGL_INCLUDE_DIRS``
+#     This should be passed to target_include_directories() if the target is not
+#     used for linking
+# ``EGL_DEFINITIONS``
+#     This should be passed to target_compile_options() if the target is not
+#     used for linking
+#
+# If ``EGL_FOUND`` is TRUE, it will also define the following imported target:
+#
+# ``EGL::EGL``
+#     The EGL library
+#
+# In general we recommend using the imported target, as it is easier to use.
+# Bear in mind, however, that if the target is in the link interface of an
+# exported library, it must be made available by the package config file.
+#
+# Since pre-1.0.0.
+
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Note: This module is originally from the KDE "Extra CMake Modules" repo,
+# adapted to work standalone. Original source:
+# https://github.com/KDE/extra-cmake-modules/blob/3b0bf71a72789eb2b79310b4f67602115e347f56/find-modules/FindEGL.cmake
+#=============================================================================
+# Copyright 2014 Alex Merry <alex.merry@kde.org>
+# Copyright 2014 Martin Gräßlin <mgraesslin@kde.org>
+# Copyright 2019, 2021 Rylie Pavlik <rylie.pavlik@collabora.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#=============================================================================
+
+include(CheckCXXSourceCompiles)
+include(CMakePushCheckState)
+
+# Use pkg-config to get the directories and then use these values
+# in the FIND_PATH() and FIND_LIBRARY() calls
+if(NOT ANDROID)
+    find_package(PkgConfig QUIET)
+    if(PKGCONFIG_FOUND)
+        pkg_check_modules(PKG_EGL QUIET egl)
+    endif()
+endif()
+
+set(EGL_DEFINITIONS ${PKG_EGL_CFLAGS_OTHER})
+
+find_path(EGL_INCLUDE_DIR
+    NAMES
+        EGL/egl.h
+    HINTS
+        ${PKG_EGL_INCLUDE_DIRS}
+)
+find_library(EGL_LIBRARY
+    NAMES
+        EGL
+    HINTS
+        ${PKG_EGL_LIBRARY_DIRS}
+)
+
+# NB: We do *not* use the version information from pkg-config, as that
+#     is the implementation version (eg: the Mesa version)
+if(EGL_INCLUDE_DIR)
+    # egl.h has defines of the form EGL_VERSION_x_y for each supported
+    # version; so the header for EGL 1.1 will define EGL_VERSION_1_0 and
+    # EGL_VERSION_1_1.  Finding the highest supported version involves
+    # finding all these defines and selecting the highest numbered.
+    file(READ "${EGL_INCLUDE_DIR}/EGL/egl.h" _EGL_header_contents)
+    string(REGEX MATCHALL
+        "[ \t]EGL_VERSION_[0-9_]+"
+        _EGL_version_lines
+        "${_EGL_header_contents}"
+    )
+    unset(_EGL_header_contents)
+    foreach(_EGL_version_line ${_EGL_version_lines})
+        string(REGEX REPLACE
+            "[ \t]EGL_VERSION_([0-9_]+)"
+            "\\1"
+            _version_candidate
+            "${_EGL_version_line}"
+        )
+        string(REPLACE "_" "." _version_candidate "${_version_candidate}")
+        if(NOT DEFINED EGL_VERSION OR EGL_VERSION VERSION_LESS _version_candidate)
+            set(EGL_VERSION "${_version_candidate}")
+        endif()
+    endforeach()
+    unset(_EGL_version_lines)
+endif()
+
+cmake_push_check_state(RESET)
+list(APPEND CMAKE_REQUIRED_LIBRARIES "${EGL_LIBRARY}")
+list(APPEND CMAKE_REQUIRED_INCLUDES "${EGL_INCLUDE_DIR}")
+
+check_cxx_source_compiles("
+#include <EGL/egl.h>
+
+int main(int argc, char *argv[]) {
+    EGLint x = 0; EGLDisplay dpy = 0; EGLContext ctx = 0;
+    eglDestroyContext(dpy, ctx);
+}" HAVE_EGL)
+
+cmake_pop_check_state()
+
+set(required_vars EGL_INCLUDE_DIR HAVE_EGL)
+if(NOT EMSCRIPTEN)
+    list(APPEND required_vars EGL_LIBRARY)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(EGL
+    FOUND_VAR
+        EGL_FOUND
+    REQUIRED_VARS
+        ${required_vars}
+    VERSION_VAR
+        EGL_VERSION
+)
+
+if(EGL_FOUND AND NOT TARGET EGL::EGL)
+    if (EMSCRIPTEN)
+        add_library(EGL::EGL INTERFACE IMPORTED)
+        # Nothing further to be done, system include paths have headers and linkage is implicit.
+    else()
+        add_library(EGL::EGL UNKNOWN IMPORTED)
+        set_target_properties(EGL::EGL PROPERTIES
+            IMPORTED_LOCATION "${EGL_LIBRARY}"
+            INTERFACE_COMPILE_OPTIONS "${EGL_DEFINITIONS}"
+            INTERFACE_INCLUDE_DIRECTORIES "${EGL_INCLUDE_DIR}"
+        )
+    endif()
+endif()
+
+mark_as_advanced(EGL_LIBRARY EGL_INCLUDE_DIR HAVE_EGL)
+
+# compatibility variables
+set(EGL_LIBRARIES ${EGL_LIBRARY})
+set(EGL_INCLUDE_DIRS ${EGL_INCLUDE_DIR})
+set(EGL_VERSION_STRING ${EGL_VERSION})
+
+include(FeatureSummary)
+set_package_properties(EGL PROPERTIES
+    URL "https://www.khronos.org/egl/"
+    DESCRIPTION "A platform-independent mechanism for creating rendering surfaces for use with other graphics libraries, such as OpenGL|ES and OpenVG."
+)

--- a/cmake/FindOpenGLES.cmake
+++ b/cmake/FindOpenGLES.cmake
@@ -1,0 +1,262 @@
+# Copyright 2020-2021, Collabora, Ltd.
+#
+# SPDX-License-Identifier: BSL-1.0
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+#
+# Original Author:
+# 2020-2021, Rylie Pavlik <rylie.pavlik@collabora.com> <rylie@ryliepavlik.com>
+
+#[[.rst:
+FindOpenGLES
+---------------
+
+Find the OpenGL ES graphics API.
+
+Components
+^^^^^^^^^^
+
+The following components are supported:
+
+* ``V1`` - OpenGL ES 1 (including emulation on OpenGL ES 2)
+* ``V2`` - OpenGL ES 2
+* ``V3`` - OpenGL ES 3
+* ``V31` - OpenGL ES 3.1 - same as 3 but checking also for gl31.h
+* ``V32` - OpenGL ES 3.2 - same as 3 but checking also for gl32.h
+
+If none are specified, the default is ``V2``.
+
+Targets
+^^^^^^^
+
+If successful, some subset of the following imported targets are created.
+
+* ``OpenGLES::OpenGLESv1``
+* ``OpenGLES::OpenGLESv2``
+* ``OpenGLES::OpenGLESv3``
+* ``OpenGLES::OpenGLESv31``
+* ``OpenGLES::OpenGLESv32``
+
+Cache variables
+^^^^^^^^^^^^^^^
+
+The following cache variable may also be set to assist/control the operation of this module:
+
+``OpenGLES_ROOT_DIR``
+ The root to search for OpenGLES.
+#]]
+
+set(OpenGLES_ROOT_DIR
+    "${OpenGLES_ROOT_DIR}"
+    CACHE PATH "Root to search for OpenGLES")
+
+if(NOT OpenGLES_FIND_COMPONENTS)
+    set(OpenGLES_FIND_COMPONENTS V2)
+endif()
+
+if(NOT ANDROID)
+    find_package(PkgConfig QUIET)
+    if(PKG_CONFIG_FOUND)
+        set(_old_prefix_path "${CMAKE_PREFIX_PATH}")
+        # So pkg-config uses OpenGLES_ROOT_DIR too.
+        if(OpenGLES_ROOT_DIR)
+            list(APPEND CMAKE_PREFIX_PATH ${OpenGLES_ROOT_DIR})
+        endif()
+        pkg_check_modules(PC_glesv1_cm QUIET glesv1_cm)
+        pkg_check_modules(PC_glesv2 QUIET glesv2)
+        # Restore
+        set(CMAKE_PREFIX_PATH "${_old_prefix_path}")
+    endif()
+endif()
+
+find_path(
+    OpenGLES_V1_INCLUDE_DIR
+    NAMES GLES/gl.h
+    PATHS ${OpenGLES_ROOT_DIR}
+    HINTS ${PC_glesv2_INCLUDE_DIRS} ${PC_glesv1_cm_INCLUDE_DIRS}
+    PATH_SUFFIXES include)
+find_path(
+    OpenGLES_V2_INCLUDE_DIR
+    NAMES GLES2/gl2.h
+    PATHS ${OpenGLES_ROOT_DIR}
+    HINTS ${PC_glesv2_INCLUDE_DIRS} ${PC_glesv1_cm_INCLUDE_DIRS}
+    PATH_SUFFIXES include)
+find_path(
+    OpenGLES_V3_INCLUDE_DIR
+    NAMES GLES3/gl3.h
+    PATHS ${OpenGLES_ROOT_DIR}
+    HINTS ${OpenGLES_V1_INCLUDE_DIR} ${OpenGLES_V2_INCLUDE_DIR}
+          ${PC_glesv2_INCLUDE_DIRS} ${PC_glesv1_cm_INCLUDE_DIRS}
+    PATH_SUFFIXES include)
+find_path(
+    OpenGLES_V31_INCLUDE_DIR
+    NAMES GLES3/gl31.h
+    PATHS ${OpenGLES_ROOT_DIR}
+    HINTS ${OpenGLES_V1_INCLUDE_DIR} ${OpenGLES_V2_INCLUDE_DIR}
+          ${OpenGLES_V3_INCLUDE_DIR} ${PC_glesv2_INCLUDE_DIRS}
+          ${PC_glesv1_cm_INCLUDE_DIRS}
+    PATH_SUFFIXES include)
+find_path(
+    OpenGLES_V32_INCLUDE_DIR
+    NAMES GLES3/gl32.h
+    PATHS ${OpenGLES_ROOT_DIR}
+    HINTS ${OpenGLES_V1_INCLUDE_DIR} ${OpenGLES_V2_INCLUDE_DIR}
+          ${OpenGLES_V3_INCLUDE_DIR} ${OpenGLES_V31_INCLUDE_DIR}
+          ${PC_glesv2_INCLUDE_DIRS} ${PC_glesv1_cm_INCLUDE_DIRS}
+    PATH_SUFFIXES include)
+
+find_library(
+    OpenGLES_V1_LIBRARY
+    NAMES GLES GLESv1_CM
+    PATHS ${OpenGLES_ROOT_DIR}
+    HINTS ${PC_glesv1_cm_LIBRARY_DIRS}
+    PATH_SUFFIXES lib)
+find_library(
+    OpenGLES_V2_LIBRARY
+    NAMES GLESv2 OpenGLES # for Apple framework
+    PATHS ${OpenGLES_ROOT_DIR}
+    HINTS ${PC_glesv2_LIBRARY_DIRS}
+    PATH_SUFFIXES lib)
+find_library(
+    OpenGLES_V3_LIBRARY
+    NAMES GLESv3
+    PATHS ${OpenGLES_ROOT_DIR}
+    HINTS ${PC_glesv2_LIBRARY_DIRS}
+    PATH_SUFFIXES lib)
+
+if(OpenGLES_V2_LIBRARY AND NOT OpenGLES_V3_LIBRARY)
+    set(OpenGLES_V3_LIBRARY ${OpenGLES_V2_LIBRARY})
+endif()
+
+set(_gles_required_vars)
+foreach(_comp IN LISTS OpenGLES_FIND_COMPONENTS)
+    if(_comp STREQUAL "V1")
+        list(APPEND _gles_required_vars OpenGLES_V1_LIBRARY
+             OpenGLES_V1_INCLUDE_DIR)
+        if(OpenGLES_V1_INCLUDE_DIR AND OpenGLES_V1_LIBRARY)
+            set(OpenGLES_${_comp}_FOUND TRUE)
+        else()
+            set(OpenGLES_${_comp}_FOUND FALSE)
+        endif()
+    elseif(_comp STREQUAL "V2")
+        list(APPEND _gles_required_vars OpenGLES_V2_LIBRARY
+             OpenGLES_V2_INCLUDE_DIR)
+        if(OpenGLES_V2_INCLUDE_DIR AND OpenGLES_V2_LIBRARY)
+            set(OpenGLES_${_comp}_FOUND TRUE)
+        else()
+            set(OpenGLES_${_comp}_FOUND FALSE)
+        endif()
+    elseif(_comp STREQUAL "V3")
+        list(APPEND _gles_required_vars OpenGLES_V3_LIBRARY
+             OpenGLES_V3_INCLUDE_DIR)
+        if(OpenGLES_V3_INCLUDE_DIR AND OpenGLES_V3_LIBRARY)
+            set(OpenGLES_${_comp}_FOUND TRUE)
+        else()
+            set(OpenGLES_${_comp}_FOUND FALSE)
+        endif()
+    elseif(_comp STREQUAL "V31")
+        list(APPEND _gles_required_vars OpenGLES_V3_LIBRARY
+             OpenGLES_V31_INCLUDE_DIR)
+
+        if(OpenGLES_V31_INCLUDE_DIR AND OpenGLES_V3_LIBRARY)
+            set(OpenGLES_${_comp}_FOUND TRUE)
+        else()
+            set(OpenGLES_${_comp}_FOUND FALSE)
+        endif()
+    elseif(_comp STREQUAL "V32")
+        list(APPEND _gles_required_vars OpenGLES_V3_LIBRARY
+             OpenGLES_V32_INCLUDE_DIR)
+        if(OpenGLES_V32_INCLUDE_DIR AND OpenGLES_V3_LIBRARY)
+            set(OpenGLES_${_comp}_FOUND TRUE)
+        else()
+            set(OpenGLES_${_comp}_FOUND FALSE)
+        endif()
+    else()
+        message(
+            WARNING "${_comp} is not a recognized OpenGL-ES component/version")
+        set(OpenGLES_${_comp}_FOUND FALSE)
+    endif()
+endforeach()
+if(_gles_required_vars)
+    list(REMOVE_DUPLICATES _gles_required_vars)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+    OpenGLES
+    REQUIRED_VARS ${_gles_required_vars}
+    HANDLE_COMPONENTS)
+if(OpenGLES_FOUND)
+    if(OpenGLES_V1_FOUND AND NOT TARGET OpenGLES::OpenGLESv1)
+        add_library(OpenGLES::OpenGLESv1 SHARED IMPORTED)
+
+        set_target_properties(
+            OpenGLES::OpenGLESv1
+            PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                       "${OpenGLES_V1_INCLUDE_DIR}"
+                       IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                       IMPORTED_LOCATION ${OpenGLES_V1_LIBRARY})
+    endif()
+    if(OpenGLES_V2_FOUND AND NOT TARGET OpenGLES::OpenGLESv2)
+        add_library(OpenGLES::OpenGLESv2 SHARED IMPORTED)
+
+        set_target_properties(
+            OpenGLES::OpenGLESv2
+            PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                       "${OpenGLES_V2_INCLUDE_DIR}"
+                       IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                       IMPORTED_LOCATION ${OpenGLES_V2_LIBRARY})
+    endif()
+    if(OpenGLES_V3_FOUND)
+        if(NOT TARGET OpenGLES::OpenGLESv3)
+            add_library(OpenGLES::OpenGLESv3 SHARED IMPORTED)
+
+            set_target_properties(
+                OpenGLES::OpenGLESv3
+                PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                           "${OpenGLES_V3_INCLUDE_DIR}"
+                           IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                           IMPORTED_LOCATION ${OpenGLES_V3_LIBRARY})
+        endif()
+        if(OpenGLES_V31_FOUND AND NOT TARGET OpenGLES::OpenGLESv31)
+            add_library(OpenGLES::OpenGLESv31 SHARED IMPORTED)
+
+            set_target_properties(
+                OpenGLES::OpenGLESv31
+                PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                           "${OpenGLES_V31_INCLUDE_DIR}"
+                           IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                           IMPORTED_LOCATION ${OpenGLES_V3_LIBRARY})
+        endif()
+        if(OpenGLES_V32_FOUND AND NOT TARGET OpenGLES::OpenGLESv32)
+            add_library(OpenGLES::OpenGLESv32 SHARED IMPORTED)
+
+            set_target_properties(
+                OpenGLES::OpenGLESv32
+                PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                           "${OpenGLES_V32_INCLUDE_DIR}"
+                           IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                           IMPORTED_LOCATION ${OpenGLES_V3_LIBRARY})
+        endif()
+    endif()
+    mark_as_advanced(
+        OpenGLES_V1_LIBRARY
+        OpenGLES_V1_INCLUDE_DIR
+        OpenGLES_V2_LIBRARY
+        OpenGLES_V2_INCLUDE_DIR
+        OpenGLES_V3_LIBRARY
+        OpenGLES_V3_INCLUDE_DIR
+        OpenGLES_V31_INCLUDE_DIR
+        OpenGLES_V32_INCLUDE_DIR)
+endif()
+mark_as_advanced(OpenGLES_ROOT_DIR)
+
+include(FeatureSummary)
+set_package_properties(
+    OpenGLES PROPERTIES
+    URL "https://www.khronos.org/opengles/"
+    DESCRIPTION
+        "A cross-platform graphics API, specialized for mobile and embedded, defined as a subset of desktop OpenGL."
+)


### PR DESCRIPTION
For systems that are having OpenGLES and EGL instead of OpenGL, this pr has added FindOpenGLES.cmake and FindEGL.cmake files and modified CMakeLists.txt to choose to add GLES and EGL files incase of USE_EGL flag is ON and the BUILD_TARGET is set to DESKTOP.